### PR TITLE
Add Linux support

### DIFF
--- a/Concentus.Oggfile/Concentus.Oggfile.csproj
+++ b/Concentus.Oggfile/Concentus.Oggfile.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Concentus.Oggfile</RootNamespace>
     <AssemblyName>Concentus.Oggfile</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />

--- a/Concentus/Concentus.csproj
+++ b/Concentus/Concentus.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Concentus</RootNamespace>
     <AssemblyName>Concentus</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />

--- a/Linux/TeddyBench
+++ b/Linux/TeddyBench
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# check for mono
+if ! type "mono" > /dev/null
+then
+    echo "mono could not be found. Please read the README.md for installation instructions."
+    exit
+fi
+
+# check for ffmpeg
+if !  type "ffmpeg" > /dev/null
+then
+    echo "ffmpeg could not be found. Please read the README.md for installation instructions."
+    exit
+fi
+
+# Some exports to avoid crashes
+export MONO_MANAGED_WATCHER=disabled
+export MONO_WINFORMS_XIM_STYLE=disabled
+
+# Start TeddyBench
+mono TeddyBench.exe

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It is tested with Ubuntu 20.04.
 Please install the following packages
 
 ```
-# sudo apt install mono-complete xcb ffmpeg libgdiplus
+# sudo apt install mono-complete xcb ffmpeg libgdiplus libcanberra-gtk-module libcanberra-gtk3-module
 ```
 
 ## Running

--- a/README.md
+++ b/README.md
@@ -1,3 +1,44 @@
 # Tonie file tool
 
 With this tool you can dump existing files of the famous audio box or create custom ones.
+
+# Linux
+WARNING: The `TeddyBench` Linux port has alpha status. So don't use it unless you are a developer and you are able to understand cryptic error messages. It is not fully tested but converting files should work.
+
+It is tested with Ubuntu 20.04.
+
+## Requirements
+Please install the following packages
+
+```
+# sudo apt install mono-complete xcb ffmpeg libgdiplus
+```
+
+## Running
+
+### General
+
+You have to run `TeddyBench` with `mono`. Using `wine` is not working.
+
+```
+# mono TeddyBench.exe
+```
+
+### Know issues
+For some reasons TonieBench is running unstable with mono. So you can try the following steps.
+
+**A. Running with sudo (root)**
+
+```
+# sudo mono TeddyBench.exe
+```
+
+**B. Set some environment variables**
+
+```
+# export MONO_MANAGED_WATCHER=disabled
+# export MONO_WINFORMS_XIM_STYLE=disabled
+# mono TeddyBench.exe
+```
+## Development
+You can compile it directly under Linux with `monodevelop`.

--- a/Teddy/App.config
+++ b/Teddy/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/Teddy/Teddy.csproj
+++ b/Teddy/Teddy.csproj
@@ -10,7 +10,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Teddy</RootNamespace>
     <AssemblyName>Teddy</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>

--- a/TeddyBench/MainForm.cs
+++ b/TeddyBench/MainForm.cs
@@ -870,16 +870,19 @@ namespace TeddyBench
             OpenFileDialog dlg = new OpenFileDialog();
             dlg.Multiselect = true;
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            if (dlg.ShowDialog() == DialogResult.OK)
             {
-                // Sort in alphabetical order because the Windows.Form dialog under Linux is scrappy
-                var list = dlg.FileNames.ToList();
-                list.Sort();
-                AddFiles(list.ToArray());
-            }
-            else
-            {
-                AddFiles(dlg.FileNames);
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    // Sort in alphabetical order because the Windows.Form dialog under Linux is scrappy
+                    var list = dlg.FileNames.ToList();
+                    list.Sort();
+                    AddFiles(list.ToArray());
+                }
+                else
+                {
+                    AddFiles(dlg.FileNames);
+                }
             }
         }
 

--- a/TeddyBench/MainForm.cs
+++ b/TeddyBench/MainForm.cs
@@ -870,7 +870,14 @@ namespace TeddyBench
             OpenFileDialog dlg = new OpenFileDialog();
             dlg.Multiselect = true;
 
-            if (dlg.ShowDialog() == DialogResult.OK)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                // Sort in alphabetical order because the Windows.Form dialog under Linux is scrappy
+                var list = dlg.FileNames.ToList();
+                list.Sort();
+                AddFiles(list.ToArray());
+            }
+            else
             {
                 AddFiles(dlg.FileNames);
             }

--- a/TeddyBench/MainForm.cs
+++ b/TeddyBench/MainForm.cs
@@ -15,6 +15,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -881,13 +882,19 @@ namespace TeddyBench
 
             if (ask.ShowDialog() == DialogResult.OK)
             {
+                string[] extensions;
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                    extensions = new String[] {".mp3", ".ogg", ".wav", "wma", "aac"};
+                else
+                    extensions = new String[] {".mp3"};
+
                 if (fileNames.Count() == 1)
                 {
                     string fileName = fileNames[0];
 
-                    if (fileName.ToLower().EndsWith(".mp3"))
+                    if (extensions.Any(ext => fileName.ToLower().EndsWith(ext)))
                     {
-                        switch (MessageBox.Show("You are about to encode a single MP3, is this right?", "Encode a MP3 file", MessageBoxButtons.YesNo))
+                        switch (MessageBox.Show("You are about to encode an single audio file, is this right?", "Encode an audio file", MessageBoxButtons.YesNo))
                         {
                             case DialogResult.No:
                                 return;
@@ -916,9 +923,9 @@ namespace TeddyBench
                 }
                 else
                 {
-                    if (fileNames.Where(f => !f.ToLower().EndsWith(".mp3")).Count() > 0)
+                    if (fileNames.Where(f => !extensions.Any(ext => f.ToLower().EndsWith(ext))).Count() > 0)
                     {
-                        MessageBox.Show("Please select MP3 files only.", "Add file...");
+                        MessageBox.Show("Please select supported audio files only.", "Add file...");
                         return;
                     }
 

--- a/TeddyBench/TeddyBench.csproj
+++ b/TeddyBench/TeddyBench.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\ILMerge.3.0.40\build\ILMerge.props" Condition="Exists('..\packages\ILMerge.3.0.40\build\ILMerge.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>

--- a/TonieAudio/TonieAudio.cs
+++ b/TonieAudio/TonieAudio.cs
@@ -506,8 +506,12 @@ namespace TonieFile
                                     prefixResampled.Write(prefixWavBytes, 0, prefixWavBytes.Length);
                                     prefixResampled.Seek(0, SeekOrigin.Begin);
 
-                                    // Skip header, for some reason ffmpeg uses 46 bytes instead of 44 bytes
-                                    prefixResampled.Read(buffer, 0, 46);
+                                    // Skip WAV header
+                                    byte[] bytes = new byte[4];
+                                    prefixResampled.Seek(16, 0);
+                                    prefixResampled.Read(bytes, 0, 4);
+                                    int Subchunk1Size = BitConverter.ToInt32(bytes, 0); // Get FMT size
+                                    prefixResampled.Read(buffer, 0, Subchunk1Size + 8); // Date starts at FMT size + 8 byte
                                 }
                                 else
                                 {
@@ -617,8 +621,12 @@ namespace TonieFile
                             streamResampled.Write(wavBytes, 0, wavBytes.Length);
                             streamResampled.Seek(0, SeekOrigin.Begin);
 
-                            // Skip header, for some reason ffmpeg uses 46 bytes instead of 44 bytes
-                            streamResampled.Read(buffer, 0, 46);
+                            // Skip WAV header
+                            byte[] bytes = new byte[4];
+                            streamResampled.Seek(16, 0);
+                            streamResampled.Read(bytes, 0, 4);
+                            int Subchunk1Size = BitConverter.ToInt32(bytes, 0); // Get FMT size
+                            streamResampled.Read(buffer, 0, Subchunk1Size + 8); // Date starts at FMT size + 8 byte
                         }
                         else
                         {

--- a/TonieAudio/TonieAudio.cs
+++ b/TonieAudio/TonieAudio.cs
@@ -288,9 +288,15 @@ namespace TonieFile
                 }
                 else if (File.Exists(item))
                 {
-                    if (!item.ToLower().EndsWith(".mp3"))
+                    string[] extensions;
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                        extensions = new String[] { ".mp3", ".ogg", ".wav", "wma", "aac" };
+                    else
+                        extensions = new String[] { ".mp3" };
+
+                    if (!extensions.Any(ext => item.ToLower().EndsWith(ext)))
                     {
-                        throw new InvalidDataException("Specified item '" + item + "' is no MP3");
+                        throw new InvalidDataException("Specified item '" + item + "' is no a supported audio file");
                     }
                     FileList.Add(item);
                 }

--- a/TonieAudio/TonieAudio.cs
+++ b/TonieAudio/TonieAudio.cs
@@ -41,6 +41,9 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xabe.FFmpeg;
 using static TonieFile.ProtoCoder;
 
 namespace TonieFile
@@ -242,7 +245,11 @@ namespace TonieFile
         {
             foreach (var source in sources)
             {
-                string item = source.Trim('"').Trim(Path.DirectorySeparatorChar);
+                string item;
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                    item = source;
+                else
+                    item = source.Trim('"').Trim(Path.DirectorySeparatorChar);
 
                 if (Directory.Exists(item))
                 {
@@ -439,11 +446,82 @@ namespace TonieFile
 
                             try
                             {
-                                var prefixStream = new Mp3FileReader(prefixFile);
-                                var prefixResampled = new MediaFoundationResampler(prefixStream, outFormat);
+                                Stream prefixResampled = new MemoryStream();
+
+                                // Linux
+                                string prefixTmpWavFile = "";
+
+                                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                                {
+                                    prefixTmpWavFile = Path.ChangeExtension(Path.GetTempFileName(), "wav");
+
+                                    //Console.Write(" Convert file " + sourceFile + " to WAV. Temp file " + prefixTmpWavFile);
+
+                                    // The isReady flag and error test variables are not a nice solution but is working
+                                    bool isReadyPrefix = false;
+                                    String FFmpegErrorTextPrefix = "";
+
+                                    // Convert to WAV
+                                    Task.Run(async () =>
+                                    {
+                                        try
+                                        {
+                                            // Convert to WAV and resample
+                                            IMediaInfo prefixInputFile = await FFmpeg.GetMediaInfo(sourceFile);
+
+                                            IAudioStream prefixAudioStream = prefixInputFile.AudioStreams.First()
+                                                .SetCodec(AudioCodec.pcm_f32le)
+                                                .SetChannels(2)
+                                                .SetSampleRate(samplingRate);
+
+                                            IConversionResult prefixConversionResult = await FFmpeg.Conversions.New()
+                                                .AddStream(prefixAudioStream)
+                                                .SetOutput(prefixTmpWavFile)
+                                                .Start();
+                                        }
+                                        catch (Exception e)
+                                        {
+                                            FFmpegErrorTextPrefix = e.Message;
+                                            throw new Exception("FFmepg error " + e.Message + "\n");
+                                        }
+
+                                        isReadyPrefix = true;
+                                    });
+
+                                    while (!isReadyPrefix)
+                                    {
+                                        Thread.Sleep(200);
+                                        if (FFmpegErrorTextPrefix != "")
+                                            throw new Exception("FFmepg error: " + FFmpegErrorTextPrefix + "\n");
+                                    }
+
+                                    // Read WAV file
+                                    byte[] prefixWavBytes = File.ReadAllBytes(prefixTmpWavFile);
+                                    prefixResampled.Write(prefixWavBytes, 0, prefixWavBytes.Length);
+                                    prefixResampled.Seek(0, SeekOrigin.Begin);
+
+                                    // Skip header, for some reason ffmpeg uses 46 bytes instead of 44 bytes
+                                    prefixResampled.Read(buffer, 0, 46);
+                                }
+                                else
+                                {
+                                    var prefixStream = new Mp3FileReader(prefixFile);
+                                    var prefixResampledTmp = new MediaFoundationResampler(prefixStream, outFormat);
+
+                                    // Convert NAudioStream to System.IO.Stream
+                                    byte[] sampleByte = { 0 };
+                                    int read;
+                                    while ((read = prefixResampledTmp.Read(sampleByte, 0, sampleByte.Length)) > 0)
+                                    {
+                                        prefixResampled.Write(sampleByte, 0, read);
+                                    }
+
+                                    prefixResampled.Seek(0, SeekOrigin.Begin);
+                                }
 
                                 while (true)
                                 {
+
                                     bytesReturned = prefixResampled.Read(buffer, 0, buffer.Length);
 
                                     if (bytesReturned <= 0)
@@ -454,7 +532,11 @@ namespace TonieFile
                                     bool isEmpty = (buffer.Where(v => v != 0).Count() == 0);
                                     if (!isEmpty)
                                     {
-                                        float[] sampleBuffer = ConvertToFloat(buffer, bytesReturned, channels);
+                                        float[] sampleBuffer;
+                                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                                            sampleBuffer = MemoryMarshal.Cast<byte, float>(buffer.AsSpan()).ToArray();
+                                        else
+                                            sampleBuffer = ConvertToFloat(buffer, bytesReturned, channels);
 
                                         if ((outputData.Length + 0x1000 + sampleBuffer.Length) >= maxSize)
                                         {
@@ -464,6 +546,9 @@ namespace TonieFile
                                     }
                                     lastIndex = (uint)oggOut.PageCounter;
                                 }
+
+                                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                                    File.Delete(prefixTmpWavFile);
                             }
                             catch (Exception ex)
                             {
@@ -471,9 +556,79 @@ namespace TonieFile
                             }
                         }
 
+                        Stream streamResampled = new MemoryStream();
+
+                        // Linux
+                        string tmpWavFile = "";
+
                         /* then the real audio file */
-                        var stream = new Mp3FileReader(sourceFile);
-                        var streamResampled = new MediaFoundationResampler(stream, outFormat);
+                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                        {
+                            tmpWavFile = Path.ChangeExtension(Path.GetTempFileName(), "wav");
+
+                            //Console.Write(" Convert file " + sourceFile + " to WAV. Temp file " + TmpWavFile);
+
+                            // The isReady flag and error test variables are not a nice solution but is working
+                            bool isReady = false;
+                            String FFmpegErrorText = "";
+
+                            // Convert to WAV and resample
+                            Task.Run(async () =>
+                            {
+                                try
+                                {
+                                    IMediaInfo inputFile = await FFmpeg.GetMediaInfo(sourceFile);
+
+                                    IAudioStream audioStream = inputFile.AudioStreams.First()
+                                        .SetCodec(AudioCodec.pcm_f32le)
+                                        .SetChannels(2)
+                                        .SetSampleRate(samplingRate);
+
+                                    IConversionResult conversionResult = await FFmpeg.Conversions.New()
+                                        .AddStream(audioStream)
+                                        .SetOutput(tmpWavFile)
+                                        .Start();
+                                }
+                                catch (Exception e)
+                                {
+                                    FFmpegErrorText = e.Message;
+                                    Console.WriteLine(e.Message);
+                                    throw new Exception("FFmepg error " + e.Message + "\n");
+                                }
+
+                                isReady = true;
+                            });
+
+                            while (!isReady)
+                            {
+                                Thread.Sleep(200);
+                                if (FFmpegErrorText != "")
+                                    throw new Exception("FFmepg error: " + FFmpegErrorText + "\n");
+                            }
+
+                            // Read WAV file
+                            byte[] wavBytes = File.ReadAllBytes(tmpWavFile);
+                            streamResampled.Write(wavBytes, 0, wavBytes.Length);
+                            streamResampled.Seek(0, SeekOrigin.Begin);
+
+                            // Skip header, for some reason ffmpeg uses 46 bytes instead of 44 bytes
+                            streamResampled.Read(buffer, 0, 46);
+                        }
+                        else
+                        {
+                            var stream = new Mp3FileReader(sourceFile);
+                            var streamResampledTmp = new MediaFoundationResampler(stream, outFormat);
+
+                            // Convert NAudioStream to System.IO.Stream
+                            byte[] sampleByte = { 0 };
+                            int read;
+                            while ((read = streamResampledTmp.Read(sampleByte, 0, sampleByte.Length)) > 0)
+                            {
+                                streamResampled.Write(sampleByte, 0, read);
+                            }
+
+                            streamResampled.Seek(0, SeekOrigin.Begin);
+                        }
 
                         while (true)
                         {
@@ -485,7 +640,7 @@ namespace TonieFile
                             }
                             totalBytesRead += bytesReturned;
 
-                            float progress = (float)stream.Position / stream.Length;
+                            float progress = (float)streamResampled.Position / streamResampled.Length;
 
                             if ((int)(progress * 20) != lastPct)
                             {
@@ -506,15 +661,22 @@ namespace TonieFile
                             bool isEmpty = (buffer.Where(v => v != 0).Count() == 0);
                             if (!isEmpty)
                             {
-                                float[] sampleBuffer = ConvertToFloat(buffer, bytesReturned, channels);
-
+                                float[] sampleBuffer;
+                                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                                    sampleBuffer = MemoryMarshal.Cast<byte, float>(buffer.AsSpan()).ToArray();
+                                else
+                                    sampleBuffer = ConvertToFloat(buffer, bytesReturned, channels);
+                                   
                                 oggOut.WriteSamples(sampleBuffer, 0, sampleBuffer.Length);
                             }
                             lastIndex = (uint)oggOut.PageCounter;
                         }
 
                         Console.WriteLine("]");
-                        stream.Close();
+                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                            File.Delete(tmpWavFile);
+
+                        streamResampled.Close();
                     }
                     catch (OpusOggWriteStream.PaddingException e)
                     {
@@ -534,7 +696,7 @@ namespace TonieFile
                     catch (Exception e)
                     {
                         Console.WriteLine();
-                        throw new Exception("Failed processing " + sourceFile);
+                        throw new Exception("Failed processing " + sourceFile + "\n Error: " + e.Message + "\n");
                     }
 
                     if (!warned && outputData.Length >= maxSize / 2)

--- a/TonieAudio/TonieAudio.cs
+++ b/TonieAudio/TonieAudio.cs
@@ -511,7 +511,18 @@ namespace TonieFile
                                     prefixResampled.Seek(16, 0);
                                     prefixResampled.Read(bytes, 0, 4);
                                     int Subchunk1Size = BitConverter.ToInt32(bytes, 0); // Get FMT size
-                                    prefixResampled.Read(buffer, 0, Subchunk1Size + 8); // Date starts at FMT size + 8 byte
+
+                                    // Skip some header information
+                                    prefixResampled.Read(buffer, 0, Subchunk1Size + 12); // Data starts at FMT size + 12 bytes
+
+                                    // Read data chunk
+                                    prefixResampled.Read(bytes, 0, 4);
+                                    var str = System.Text.Encoding.Default.GetString(bytes);
+                                    if (str != "data")
+                                        throw new Exception("WAV error: Data section not found \n");
+
+                                    // Skip data length
+                                    prefixResampled.Read(bytes, 0, 4);
                                 }
                                 else
                                 {
@@ -597,6 +608,7 @@ namespace TonieFile
                                     IConversionResult conversionResult = await FFmpeg.Conversions.New()
                                         .AddStream(audioStream)
                                         .SetOutput(tmpWavFile)
+                                        .AddParameter("-map_metadata -1 -fflags +bitexact -flags:v +bitexact -flags:a +bitexact") // Remove meta data
                                         .Start();
                                 }
                                 catch (Exception e)
@@ -626,7 +638,18 @@ namespace TonieFile
                             streamResampled.Seek(16, 0);
                             streamResampled.Read(bytes, 0, 4);
                             int Subchunk1Size = BitConverter.ToInt32(bytes, 0); // Get FMT size
-                            streamResampled.Read(buffer, 0, Subchunk1Size + 8); // Date starts at FMT size + 8 byte
+
+                            // Skip some header information
+                            streamResampled.Read(buffer, 0, Subchunk1Size + 12); // Data starts at FMT size + 12 bytes
+
+                            // Read data chunk
+                            streamResampled.Read(bytes, 0, 4);
+                            var str = System.Text.Encoding.Default.GetString(bytes);
+                            if(str != "data")
+                                throw new Exception("WAV error: Data section not found \n");
+
+                            // Skip data length
+                            streamResampled.Read(bytes, 0, 4);
                         }
                         else
                         {

--- a/TonieAudio/TonieAudio.csproj
+++ b/TonieAudio/TonieAudio.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TonieAudio</RootNamespace>
     <AssemblyName>TonieAudio</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
@@ -18,7 +18,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\TeddyBench\bin\Debug</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -37,7 +37,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
@@ -47,7 +46,6 @@
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
@@ -57,7 +55,6 @@
     <Optimize>false</Optimize>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <DebugSymbols>true</DebugSymbols>
@@ -68,7 +65,6 @@
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
@@ -82,6 +78,23 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Xabe.FFmpeg">
+      <HintPath>..\packages\Xabe.FFmpeg.4.4.0\lib\netstandard2.0\Xabe.FFmpeg.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Buffers">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="System.Numerics.Vectors">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Memory">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/TonieAudio/packages.config
+++ b/TonieAudio/packages.config
@@ -3,4 +3,9 @@
   <package id="JetBrains.Annotations" version="2018.3.0" targetFramework="net46" />
   <package id="NAudio" version="1.10.0" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net46" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net48" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net48" />
+  <package id="Xabe.FFmpeg" version="4.4.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
This pull requests add Linux support by using mono.

* Audio decoding is done by `ffmpeg` instead of `NAudio`
* Switch to .net 4.8 (necessary for Xabe.FFmpeg)
* Add support for OGG, WMA, WAV files (only for Linux)
* Add sorting of input files to alphabetical order (only for Linux)
* Add Linux section to README.md
* Add Linux start script

Test binaries can be found here: https://github.com/AlbrechtL/teddy/releases/tag/v1.2.4-linux_2