### PR TITLE
two different sort methods for TrackSortDialog added + TAF limitation warnings added (99 files and 12h)

### DIFF
--- a/TeddyBench/TeddyMain.cs
+++ b/TeddyBench/TeddyMain.cs
@@ -131,7 +131,17 @@ namespace TeddyBench
                     return 1;
                 }
 
-                int returnVal = String.Compare(s1, s2);
+                int returnVal = 0;
+
+                if (Characteristic != 2)
+                {
+                    returnVal = String.Compare(s1, s2);
+                }
+                else
+                {
+                    // do not use the string representation to avoid wrong sort results
+                    returnVal = DateTime.Compare(t1.FileInfo.CreationTime, t2.FileInfo.CreationTime);
+                }
 
                 return (Order ? 1 : -1) * returnVal;
             }

--- a/TeddyBench/TrackSortDialog.Designer.cs
+++ b/TeddyBench/TrackSortDialog.Designer.cs
@@ -47,6 +47,7 @@
             this.splitContainer2 = new System.Windows.Forms.SplitContainer();
             this.btnDown = new System.Windows.Forms.Button();
             this.btnUp = new System.Windows.Forms.Button();
+            this.cmbSorting = new System.Windows.Forms.ComboBox();
             this.lstTracks = new System.Windows.Forms.ListView();
             this.columnHeader1 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader2 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
@@ -114,6 +115,7 @@
             // 
             this.splitContainer2.Panel1.Controls.Add(this.btnDown);
             this.splitContainer2.Panel1.Controls.Add(this.btnUp);
+            this.splitContainer2.Panel1.Controls.Add(this.cmbSorting);
             // 
             // splitContainer2.Panel2
             // 
@@ -143,6 +145,20 @@
             this.btnUp.Text = "Up";
             this.btnUp.UseVisualStyleBackColor = true;
             this.btnUp.Click += new System.EventHandler(this.btnUp_Click);
+            // 
+            // cmbSorting
+            // 
+            this.cmbSorting.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbSorting.FormattingEnabled = true;
+            this.cmbSorting.Items.AddRange(new object[] {
+            "Track",
+            "Filename"});
+            this.cmbSorting.Location = new System.Drawing.Point(0, 46);
+            this.cmbSorting.Name = "cmbSorting";
+            this.cmbSorting.Size = new System.Drawing.Size(85, 23);
+            this.cmbSorting.TabIndex = 0;
+            this.cmbSorting.SelectedIndex = 0;
+            this.cmbSorting.SelectedIndexChanged += new System.EventHandler(this.cmbSorting_SelectedIndexChanged);
             // 
             // lstTracks
             // 
@@ -212,6 +228,7 @@
         private System.Windows.Forms.SplitContainer splitContainer2;
         private System.Windows.Forms.Button btnUp;
         private System.Windows.Forms.Button btnDown;
+        private System.Windows.Forms.ComboBox cmbSorting;
         private System.Windows.Forms.ListView lstTracks;
         private System.Windows.Forms.ColumnHeader columnHeader1;
         private System.Windows.Forms.ColumnHeader columnHeader2;

--- a/TeddyBench/TrackSortDialog.cs
+++ b/TeddyBench/TrackSortDialog.cs
@@ -186,6 +186,36 @@ namespace TeddyBench
             lstTracks.Select();
         }
 
+        private void cmbSorting_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            UpdateSorting();
+        }
+
+        private void UpdateSorting()
+        {
+            FileList = new List<Tuple<string, Id3Tag>>();
+
+            var fileTuples = FileNames.Select(f => new Tuple<string, Id3Tag>(f, GetTag(f)));
+
+            if (cmbSorting.SelectedIndex == 0)
+            {
+                foreach (Tuple<string, Id3Tag> item in fileTuples.OrderBy(i => (i.Item2 == null) ? int.MaxValue : i.Item2.Track.Value))
+                {
+                    FileList.Add(item);
+                }
+            }
+            else
+            {
+                foreach (Tuple<string, Id3Tag> item in fileTuples.OrderBy(i => i.Item1))
+                {
+                    FileList.Add(item);
+                }
+            }
+
+            UpdateView();
+        }
+
+
         private void RebuildFileList()
         {
             FileList = new List<Tuple<string, Id3Tag>>();


### PR DESCRIPTION
Better sort added so that the user can choose between two methods. The old track based method is the default so that nothing is changed for the user out of the box. The user has to choose manually the new sort method at least once and can switch between them afterwards.