### PR TITLE
Adding opportunity to sort by filename or ID3-Tag or Track-No.

### DIFF
--- a/TeddyBench/TeddyBench.csproj
+++ b/TeddyBench/TeddyBench.csproj
@@ -4,7 +4,7 @@
 		<PublishSingleFile>true</PublishSingleFile>
 	</PropertyGroup>
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net481</TargetFramework>
     <OutputType>WinExe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>

--- a/TeddyBench/TrackSortDialog.Designer.cs
+++ b/TeddyBench/TrackSortDialog.Designer.cs
@@ -51,6 +51,7 @@
             this.columnHeader1 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader2 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader3 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.columnHeader4 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -149,7 +150,8 @@
             this.lstTracks.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.columnHeader1,
             this.columnHeader2,
-            this.columnHeader3});
+            this.columnHeader3,
+            this.columnHeader4});
             this.lstTracks.Dock = System.Windows.Forms.DockStyle.Fill;
             this.lstTracks.FullRowSelect = true;
             this.lstTracks.HideSelection = false;
@@ -164,6 +166,7 @@
             this.lstTracks.TabIndex = 0;
             this.lstTracks.UseCompatibleStateImageBehavior = false;
             this.lstTracks.View = System.Windows.Forms.View.Details;
+            this.lstTracks.ColumnClick += new System.Windows.Forms.ColumnClickEventHandler(this.lstTracks_ColumnClick);
             // 
             // columnHeader1
             // 
@@ -178,6 +181,10 @@
             // 
             this.columnHeader3.Text = "ID3";
             this.columnHeader3.Width = 219;
+            // 
+            // columnHeader4
+            // 
+            this.columnHeader4.Text = "Track No.";
             // 
             // TrackSortDialog
             // 
@@ -216,5 +223,6 @@
         private System.Windows.Forms.ColumnHeader columnHeader1;
         private System.Windows.Forms.ColumnHeader columnHeader2;
         private System.Windows.Forms.ColumnHeader columnHeader3;
+        private System.Windows.Forms.ColumnHeader columnHeader4;
     }
 }

--- a/TeddyBench/TrackSortDialog.cs
+++ b/TeddyBench/TrackSortDialog.cs
@@ -1,19 +1,25 @@
 ﻿using Id3;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.Drawing;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace TeddyBench
 {
+
+
     public partial class TrackSortDialog : Form
     {
         private string[] FileNames;
+        private bool isAscending = false;
+        private string[] originalColumnHeaders;
         private List<Tuple<string, Id3Tag>> FileList = new List<Tuple<string, Id3Tag>>();
 
         public TrackSortDialog()
@@ -38,6 +44,13 @@ namespace TeddyBench
             }
 
             UpdateView();
+            
+            // Store original column headers
+            originalColumnHeaders = new string[lstTracks.Columns.Count];
+            for (int i = 0; i < lstTracks.Columns.Count; i++)
+            {
+                originalColumnHeaders[i] = lstTracks.Columns[i].Text;
+            }
         }
 
         private Id3Tag GetTag(string f)
@@ -46,7 +59,8 @@ namespace TeddyBench
             {
                 Mp3 mp3 = new Mp3(f, Mp3Permissions.Read);
 
-                Id3Tag ret = mp3.GetAllTags().Where(t => t.Track.IsAssigned).FirstOrDefault();
+                //Id3Tag ret = mp3.GetAllTags().Where(t => t.Track.IsAssigned).FirstOrDefault();
+                Id3Tag ret = mp3.GetAllTags().FirstOrDefault();
 
                 return ret;
             }
@@ -68,13 +82,33 @@ namespace TeddyBench
                 lvi.Text = track.ToString();
 
                 string id3 = "";
+                string storedTrack = "";
 
                 if (item.Item2 != null)
                 {
-                    id3 = item.Item2.Artists + " - " + item.Item2.Title;
+                    string artist;
+                    if (item.Item2.Artists == null)
+                    {
+                        artist = Regex.Replace(item.Item2.Band, @"\0+$", "");
+                    } else
+                    {
+                        artist = Regex.Replace(item.Item2.Artists, @"\0+$", "");
+                    }
+
+                    id3 = artist + " - " + Regex.Replace(item.Item2.Title, @"\0+$", "");
+
+                    if (item.Item2.Track.IsAssigned)
+                    {
+                        storedTrack = item.Item2.Track.ToString();
+                    }
+
                 }
+
                 lvi.SubItems.Add(item.Item1);
                 lvi.SubItems.Add(id3);
+                lvi.SubItems.Add(item.Item2.Track);
+                // Set the ToolTip text to the full ID3 information
+                lvi.ToolTipText = id3;
 
                 lstTracks.Items.Add(lvi);
 
@@ -111,6 +145,8 @@ namespace TeddyBench
 
             int numberOfItems = lstTracks.Items.Count;
             List<object> selectedItems = new List<object>();
+            lstTracks.ListViewItemSorter = null;    // remove the sorting by column
+            isAscending = false;
 
             foreach (var item in lstTracks.SelectedItems)
             {
@@ -155,8 +191,11 @@ namespace TeddyBench
             {
                 return;
             }
+
             int numberOfItems = lstTracks.Items.Count;
             List<object> selectedItems = new List<object>();
+            lstTracks.ListViewItemSorter = null;    // remove the sorting by column
+            isAscending = false;
 
             foreach (var item in lstTracks.SelectedItems)
             {
@@ -197,5 +236,62 @@ namespace TeddyBench
                 FileList.Add((Tuple<string, Id3Tag>)item.Tag);
             }
         }
+
+        private void lstTracks_ColumnClick(object sender, ColumnClickEventArgs e)
+        {
+            if (e.Column != 0) SortListView(e.Column);
+        }
+
+        private void SortListView(int columnIndex)
+        {
+            // Use ListViewItemComparer for sorting
+            lstTracks.ListViewItemSorter = new ListViewItemComparer(columnIndex, !isAscending);
+            lstTracks.Sort();
+            isAscending = !isAscending;
+            RebuildFileList();
+        }
+
+
     }
+
+    public class ListViewItemComparer : IComparer
+    {
+        private int columnIndex;
+        private bool ascending;
+
+        public ListViewItemComparer(int columnIndex, bool ascending)
+        {
+            this.columnIndex = columnIndex;
+            this.ascending = ascending;
+        }
+
+        public int Compare(object x, object y)
+        {
+            ListViewItem item1 = (ListViewItem)x;
+            ListViewItem item2 = (ListViewItem)y;
+
+            // Get the values based on the specified column
+            string value1 = item1.SubItems[columnIndex].Text;
+            string value2 = item2.SubItems[columnIndex].Text;
+
+            // Handle potential null values
+            if (value1 == null && value2 == null)
+            {
+                return 0; // Both values are null, consider them equal
+            }
+            else if (value1 == null)
+            {
+                return ascending ? 1 : -1; // Null value comes after non-null in ascending order
+            }
+            else if (value2 == null)
+            {
+                return ascending ? -1 : 1; // Null value comes before non-null in descending order
+            }
+
+            // Compare strings based on chosen order
+            int comparison = string.Compare(value1, value2, StringComparison.OrdinalIgnoreCase);
+            return ascending ? comparison : -comparison;
+        }
+    }
+
 }

--- a/TeddyBench/TrackSortDialog.cs
+++ b/TeddyBench/TrackSortDialog.cs
@@ -43,15 +43,10 @@ namespace TeddyBench
                 FileList.Add(item);
             }
 
-            UpdateView();
-            
-            // Store original column headers
-            originalColumnHeaders = new string[lstTracks.Columns.Count];
-            for (int i = 0; i < lstTracks.Columns.Count; i++)
-            {
-                originalColumnHeaders[i] = lstTracks.Columns[i].Text;
-            }
+            UpdateView();       
+        
         }
+
 
         private Id3Tag GetTag(string f)
         {


### PR DESCRIPTION
## Please check my PR properly.:

This is a pull request addressing an issue I reported: #86 .
Please note: I did not work with C# before - Therefore I forked your repo at first. I did not work on any other code than _TrackSortDialog_, so I do not know the full picture of this application. And because of that and despite successful testing the _TrackSortDialog_ myself multiple times for now, this code might be incorrect or lead to unknown sideeffects I did not encounter myself. Anyway it can be used to implement the intention correctly, I guess.

- Update to .NET v4.8.1
- Removed the filter on reading only MP3-files where Track is assigned. **Reason:** **I can't see the reason for that filter**, however, reading the Track seems not to work correctly with the ID3-Library used. ID3v2.3 Tags created by common MP3-Tag-Editors don't seem to work regarding track data. See [reported issues](https://github.com/JeevanJames/Id3/issues) at the ID3 library.
- Added an additional column (SubItem) to show the track no. which is read from the ID3-Tag.
- Added a regex-filter to remove "\0" from ID3-Tag-Data used. **Reason:** Some ID3-Tags (written by common MP3-Tag-Editors) end with "\0" when read by the library used here and by this break the concatenation of artist & title.
- **Added a ListViewItemComparer class to add sorting by columns. Reason:** Adding files with track-data not properly processed by the ID3-library lead to incorrect order. I wanted to be able to sort the tracks not only inconveniently by the buttons "Up" or "Down" but also easily by file name or ID3-Tag. This class now allows to sort by the column by just clicking the column header.